### PR TITLE
Add a workaround for long pipe path names

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -451,9 +451,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
             try
             {
+                var workingDir = CurrentDirectoryToUse();
+                string tempDir = BuildServerConnection.GetTempPath(workingDir);
+
                 if (!UseSharedCompilation ||
                     HasToolBeenOverridden ||
-                    !BuildServerConnection.IsCompilerServerSupported)
+                    !BuildServerConnection.IsCompilerServerSupported(tempDir))
                 {
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
                 }
@@ -471,13 +474,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     // we'll just print our own message that contains the real client location
                     Log.LogMessage(ErrorString.UsingSharedCompilation, clientDir);
 
-                    var workingDir = CurrentDirectoryToUse();
                     var buildPaths = new BuildPathsAlt(
                         clientDir: clientDir,
                         // MSBuild doesn't need the .NET SDK directory
                         sdkDir: null,
                         workingDir: workingDir,
-                        tempDir: BuildServerConnection.GetTempPath(workingDir));
+                        tempDir: tempDir);
 
                     // Note: using ToolArguments here (the property) since
                     // commandLineCommands (the parameter) may have been mucked with

--- a/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
@@ -123,10 +124,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             }
         }
 
-        internal static new int RunServer(string pipeName, IClientConnectionHost clientConnectionHost = null, IDiagnosticListener listener = null, TimeSpan? keepAlive = null, CancellationToken cancellationToken = default(CancellationToken))
+        internal static new int RunServer(
+            string pipeName,
+            string tempPath,
+            IClientConnectionHost clientConnectionHost = null,
+            IDiagnosticListener listener = null,
+            TimeSpan? keepAlive = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             BuildServerController controller = new DesktopBuildServerController(new NameValueCollection());
-            return controller.RunServer(pipeName, clientConnectionHost, listener, keepAlive, cancellationToken);
+            return controller.RunServer(pipeName, tempPath, clientConnectionHost, listener, keepAlive, cancellationToken);
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -12,6 +12,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using System.IO;
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
@@ -312,7 +313,11 @@ class Hello
                 try
                 {
                     var host = new Mock<IClientConnectionHost>(MockBehavior.Strict);
-                    var result = DesktopBuildServerController.RunServer(pipeName, host.Object, keepAlive: null);
+                    var result = DesktopBuildServerController.RunServer(
+                        pipeName,
+                        Path.GetTempPath(),
+                        host.Object,
+                        keepAlive: null);
                     Assert.Equal(CommonCompiler.Failed, result);
                 }
                 finally
@@ -364,7 +369,11 @@ class Hello
                     return new TaskCompletionSource<IClientConnection>().Task;
                 });
 
-            var result = DesktopBuildServerController.RunServer(pipeName, host.Object, keepAlive: TimeSpan.FromSeconds(1));
+            var result = DesktopBuildServerController.RunServer(
+                pipeName,
+                Path.GetTempPath(),
+                host.Object,
+                keepAlive: TimeSpan.FromSeconds(1));
             Assert.Equal(CommonCompiler.Succeeded, result);
         }
 

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -243,6 +243,28 @@ End Module")
 
         #endregion
 
+        [ConditionalFact(typeof(UnixLikeOnly))]
+        public async Task ServerFailsWithLongTempPathUnix()
+        {
+            var newTempDir = _tempDirectory.CreateDirectory(new string('a', 100 - _tempDirectory.Path.Length));
+            await ApplyEnvironmentVariables(
+                new[] { new KeyValuePair<string, string>("TMPDIR", newTempDir.Path)},
+                async () =>
+            {
+                using (var serverData = ServerUtil.CreateServer())
+                {
+                    var result = RunCommandLineCompiler(
+                        CSharpCompilerClientExecutable,
+                        $"/shared:{serverData.PipeName} /nologo hello.cs",
+                        _tempDirectory,
+                        s_helloWorldSrcCs,
+                        shouldRunOnServer: false);
+                    VerifyResultAndOutput(result, _tempDirectory, "Hello, world.");
+                    await serverData.Verify(connections: 0, completed: 0).ConfigureAwait(true);
+                }
+            });
+        }
+
         [Fact]
         public async Task FallbackToCsc()
         {

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -83,10 +83,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         internal static ServerData CreateServer(
             string pipeName = null,
             ICompilerServerHost compilerServerHost = null,
-            bool failingServer = false)
+            bool failingServer = false,
+            string tempPath = null)
         {
-            pipeName = pipeName ?? Guid.NewGuid().ToString();
+            // The total pipe path must be < 92 characters on Unix, so trim this down to 10 chars
+            pipeName = pipeName ?? Guid.NewGuid().ToString().Substring(0, 10);
             compilerServerHost = compilerServerHost ?? DesktopBuildServerController.CreateCompilerServerHost();
+            tempPath = tempPath ?? Path.GetTempPath();
             var clientConnectionHost = DesktopBuildServerController.CreateClientConnectionHostForServerHost(compilerServerHost, pipeName);
 
             if (failingServer)
@@ -106,6 +109,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 {
                     DesktopBuildServerController.RunServer(
                         pipeName,
+                        tempPath,
                         clientConnectionHost,
                         listener,
                         keepAlive: TimeSpan.FromMilliseconds(-1),

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -69,8 +69,11 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// <summary>
         /// Determines if the compiler server is supported in this environment.
         /// </summary>
-        internal static bool IsCompilerServerSupported => 
-            GetPipeNameForPathOpt("") != null;
+        internal static bool IsCompilerServerSupported(string tempPath)
+        {
+            var pipeName = GetPipeNameForPathOpt("");
+            return pipeName != null && !IsPipePathTooLong(pipeName, tempPath);
+        }
 
         public static Task<BuildResponse> RunServerCompilation(
             RequestLanguage language,
@@ -296,6 +299,14 @@ namespace Microsoft.CodeAnalysis.CommandLine
             NamedPipeClientStream pipeStream;
             try
             {
+                // If the pipe path would be too long, there cannot be a server at the other end.
+                // We're not using a saved temp path here because pipes are created with
+                // Path.GetTempPath() in corefx NamedPipeClientStream and we want to replicate that behavior.
+                if (IsPipePathTooLong(pipeName, Path.GetTempPath()))
+                {
+                    return null;
+                }
+
                 // Machine-local named pipes are named "\\.\pipe\<pipename>".
                 // We use the SHA1 of the directory the compiler exes live in as the pipe name.
                 // The NamedPipeClientStream class handles the "\\.\pipe\" part for us.
@@ -550,6 +561,27 @@ namespace Microsoft.CodeAnalysis.CommandLine
             return $"{userName}.{(isAdmin ? 'T' : 'F')}.{basePipeName}";
         }
 
+        /// <summary>
+        /// Check if our constructed path is too long. On some Unix machines the pipe is a
+        /// real file in the temp directory, and there is a limit on how long the path can
+        /// be. This will never be true on Windows.
+        /// </summary>
+        internal static bool IsPipePathTooLong(string pipeName, string tempPath)
+        {
+            if (PlatformInformation.IsUnix)
+            {
+                // This is the maximum path length of Unix Domain Sockets on a number of systems.
+                // Since CoreFX implements named pipes using Unix Domain Sockets, if we exceed this
+                // length than the pipe will fail.
+                // This number is considered the smallest known max length according to
+                // http://man7.org/linux/man-pages/man7/unix.7.html
+                const int MaxPipePathLength = 92;
+                const int PrefixLength = 11; // "CoreFxPipe_".Length
+                return (tempPath.Length + PrefixLength + pipeName.Length) > MaxPipePathLength;
+            }
+            return false;
+        }
+
         internal static string GetBasePipeName(string compilerExeDirectory)
         {
             // Normalize away trailing slashes.  File APIs include / exclude this with no 
@@ -562,7 +594,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             {
                 var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(compilerExeDirectory));
                 basePipeName = Convert.ToBase64String(bytes)
-                    .Substring(0, 25) // We only have ~50 total characters on Mac, so strip this down
+                    .Substring(0, 10) // We only have ~50 total characters on Mac, so strip this down
                     .Replace("/", "_")
                     .Replace("=", string.Empty);
             }

--- a/src/Compilers/Shared/DesktopBuildClient.cs
+++ b/src/Compilers/Shared/DesktopBuildClient.cs
@@ -61,28 +61,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             return RunServerCompilationCore(_language, arguments, buildPaths, sessionKey, keepAlive, libDirectory, TimeoutOverride, TryCreateServer, cancellationToken);
         }
 
-        public static Task<BuildResponse> RunServerCompilation(
-            RequestLanguage language,
-            List<string> arguments,
-            BuildPaths buildPaths,
-            string keepAlive,
-            string libEnvVariable,
-            CancellationToken cancellationToken)
-        {
-            var pipeNameOpt = BuildServerConnection.GetPipeNameForPathOpt(buildPaths.ClientDirectory);
-
-            return RunServerCompilationCore(
-                language,
-                arguments,
-                buildPaths,
-                pipeNameOpt,
-                keepAlive,
-                libEnvVariable,
-                timeoutOverride: null,
-                tryCreateServerFunc: BuildServerConnection.TryCreateServerCore,
-                cancellationToken: cancellationToken);
-        }
-
         private static Task<BuildResponse> RunServerCompilationCore(
             RequestLanguage language,
             List<string> arguments,


### PR DESCRIPTION
There's a problem on MacOS where the pipe name may be too long to
use as a Unix domain socket. Unfortunately, there's no way in the
version of CoreFX that we reference to override the path name
used for the named pipe. If the path is too long then the compiler
server spins infinitely trying to connect to a path.

Since we can't use our own path, the best we can do right now is
abort compiler server usage if the path would be too long. This
commit adds a check on Unix machines running on CoreCLR to
detect when the constructed path will be too long, and bail out
if this is the case. The check uses private reflection into
CoreFX to fetch the final path before constructing an actual
pipe.

Cherry Pick from: https://github.com/dotnet/roslyn/pull/28841