### PR TITLE
Fix vssdk package feeds 

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -274,8 +274,8 @@
       https://dotnet.myget.org/F/sourcelink/api/v3/index.json;
       https://myget.org/F/vs-devcore/api/v3/index.json;
       https://myget.org/F/vs-editor/api/v3/index.json;
-      https://vside.myget.org/F/vssdk/api/v3/index.json;
-      https://vside.myget.org/F/vs-impl/api/v3/index.json;
+      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 


### PR DESCRIPTION
See https://github.com/dotnet/roslyn/pull/36000

Basically, Microsoft broke old package feed URLs and without this fix building Roslyn fails. Now it's successful: 

https://katana.bf.unity3d.com/projects/Roslyn/builders?roslyn_branch=fix-vssdk-package-feeds&sort=1-asc