### PR TITLE
Publish roslyn-csc Stevedore artifacts from Yamato

### DIFF
--- a/.yamato/publish_roslyn-csc_stevedore_artifacts.yml
+++ b/.yamato/publish_roslyn-csc_stevedore_artifacts.yml
@@ -7,7 +7,6 @@ agent:
 dependencies:
   - .yamato/build.yml
 commands:
-  # Script needs the version string of the source artifact (which must match StevedoreUpload args).
   - ./stevedore-build-artifacts.sh
   - curl -sSo StevedoreUpload.exe "$STEVEDORE_UPLOAD_TOOL_URL"
   - mono StevedoreUpload.exe --repo=public --version-len=12 --version="$GIT_REVISION" producedbuilds/*

--- a/.yamato/publish_roslyn-csc_stevedore_artifacts.yml
+++ b/.yamato/publish_roslyn-csc_stevedore_artifacts.yml
@@ -1,0 +1,13 @@
+name: 'Publish roslyn-csc Stevedore artifacts'
+
+agent:
+  type: Unity::VM
+  image: cds-ops/cds-ubuntu-18.04-base:stable
+  flavor: b1.small
+dependencies:
+  - .yamato/build.yml
+commands:
+  # Script needs the version string of the source artifact (which must match StevedoreUpload args).
+  - ./stevedore-build-artifacts.sh
+  - curl -sSo StevedoreUpload.exe "$STEVEDORE_UPLOAD_TOOL_URL"
+  - mono StevedoreUpload.exe --repo=public --version-len=12 --version="$GIT_REVISION" producedbuilds/*

--- a/stevedore-build-artifacts.sh
+++ b/stevedore-build-artifacts.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+artifact_path='producedbuilds/*'
+
+chmod -v +x Artifacts/Builds/Binaries/Linux/csc
+ls -l Artifacts/Builds/Binaries/Linux/csc
+chmod -v +x Artifacts/Builds/Binaries/Linux/VBCSCompiler
+ls -l Artifacts/Builds/Binaries/Linux/VBCSCompiler
+
+chmod -v +x Artifacts/Builds/Binaries/Mac/csc
+ls -l Artifacts/Builds/Binaries/Mac/csc
+chmod -v +x Artifacts/Builds/Binaries/Mac/VBCSCompiler
+ls -l Artifacts/Builds/Binaries/Mac/VBCSCompiler
+
+cp License.txt $PWD/Artifacts/Builds/Binaries/Linux/LICENSE.txt
+cp License.txt $PWD/Artifacts/Builds/Binaries/Mac/LICENSE.txt
+cp License.txt $PWD/Artifacts/Builds/Binaries/Windows/LICENSE.txt
+cp License.txt $PWD/Artifacts/Builds/Binaries/Net46/LICENSE.txt
+
+mkdir -p producedbuilds
+
+7z a producedbuilds/roslyn-csc-linux.7z $PWD/Artifacts/Builds/Binaries/Linux/*
+7z a producedbuilds/roslyn-csc-mac.7z $PWD/Artifacts/Builds/Binaries/Mac/*
+7z a producedbuilds/roslyn-csc-win64.7z $PWD/Artifacts/Builds/Binaries/Windows/*
+7z a producedbuilds/roslyn-csc-net46.7z $PWD/Artifacts/Builds/Binaries/Net46/*

--- a/stevedore-build-artifacts.sh
+++ b/stevedore-build-artifacts.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-artifact_path='producedbuilds/*'
-
 chmod -v +x Artifacts/Builds/Binaries/Linux/csc
 ls -l Artifacts/Builds/Binaries/Linux/csc
 chmod -v +x Artifacts/Builds/Binaries/Linux/VBCSCompiler


### PR DESCRIPTION
We're already using Stevedore'd Roslyn in Bee and will eventually use it
in the main repo, too, killing the old Roslyn builds.zips.
This streamlines artifact publishing by adding:

    a shell script that makes the Stevedore artifact zips
    a "Publish Stevedore artifacts" Yamato job to build and upload them
