### PR TITLE
Update Compiler to consume attribute and treat generated code (and relevant compilation units) as partial

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -339,13 +339,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // has the attribute "[CompilerGenerated]" applied to it, we ignore the partial keyword
             // requirement.  This is to get around the limitation of being unable to add to user
             // classes during compilation.
-var hasCompilerGenAttribute = declaration.Declarations
-    .Any(decl =>
-    {
-        return decl.HasAnyAttributes &&
-                decl.SyntaxReference.GetSyntax().ChildNodes().OfType<AttributeListSyntax>()
-                .Where((attribList => attribList.ToString().Contains("CompilerGenerated"))).Any();
-    });
+            var hasCompilerGenAttribute = 
+                declaration.Declarations.Any(
+                    decl =>
+                    {
+                        return decl.HasAnyAttributes && 
+                        decl.SyntaxReference.GetSyntax().ChildNodes().OfType<AttributeListSyntax>().Where(
+                            (attribList => attribList.ToString().Contains("CompilerGenerated"))
+                        ).Any();
+                    }
+                );
 
             for (var i = 0; i < partCount; i++)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -335,9 +335,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var partCount = declaration.Declarations.Length;
             var missingPartial = false;
 
-            // @davidmo On a class declaration where one has partial and the other does not, treat the other
-            // as if it did.  This is to get around adding code to classes needing partial class on any user class
-            // we want to extend as a part of our Source Generation step.
+            // @davidmo If any class declaration has another definition within the namespace that 
+            // has the attribute "[CompilerGenerated]" applied to it, we ignore the partial keyword
+            // requirement.  This is to get around the limitation of being unable to add to user
+            // classes during compilation.
 var hasCompilerGenAttribute = declaration.Declarations
     .Any(decl =>
     {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -335,6 +335,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var partCount = declaration.Declarations.Length;
             var missingPartial = false;
 
+            // @davidmo On a class declaration where one has partial and the other does not, treat the other
+            // as if it did.  This is to get around adding code to classes needing partial class on any user class
+            // we want to extend as a part of our Source Generation step.
+            var hasCompilerGenAttribute = false;
+            foreach (var decl in declaration.Declarations)
+            {
+                if (decl.HasAnyAttributes)
+                {
+                    hasCompilerGenAttribute = decl.SyntaxReference.GetSyntax().ChildNodes().OfType<AttributeListSyntax>()
+                        .Where((attribList => attribList.ToString().Contains("CompilerGenerated"))).Any();
+                }
+
+                if (hasCompilerGenAttribute)
+                    break;
+            }
+
             for (var i = 0; i < partCount; i++)
             {
                 var decl = declaration.Declarations[i];
@@ -342,7 +358,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (partCount > 1 && (mods & DeclarationModifiers.Partial) == 0)
                 {
-                    missingPartial = true;
+                    // @davidmo instead of just failing we compare against the hasCompilerGenAttribute
+                    // and if so then we still consider this MergedTypeDeclaration as partial and valid.
+                    missingPartial = !hasCompilerGenAttribute;
                 }
 
                 if (!modifierErrors)
@@ -1027,7 +1045,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             //                                 |<-----------distanceFromCtorBody----------->|
             // [      initializer 0    ][ initializer 1 ][ initializer 2 ][ctor initializer][ctor body]
             // |<--preceding init len-->|      ^
-            //                             position 
+            //                             position
 
             int initializersLength = isStatic ? membersAndInitializers.StaticInitializersSyntaxLength : membersAndInitializers.InstanceInitializersSyntaxLength;
             int distanceFromInitializerStart = position - siblingInitializers[index].Syntax.Span.Start;
@@ -1296,7 +1314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// During early attribute decoding, we consider a safe subset of all members that will not
         /// cause cyclic dependencies.  Get all such members for this symbol.
-        /// 
+        ///
         /// In particular, this method will return nested types and fields (other than auto-property
         /// backing fields).
         /// </summary>
@@ -1308,7 +1326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// During early attribute decoding, we consider a safe subset of all members that will not
         /// cause cyclic dependencies.  Get all such members for this symbol that have a particular name.
-        /// 
+        ///
         /// In particular, this method will return nested types and fields (other than auto-property
         /// backing fields).
         /// </summary>
@@ -1519,23 +1537,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // not need any special handling in this method.
             //
             // However, we must have special handling for conversions because conversions
-            // use a completely different rule for detecting collisions between two 
+            // use a completely different rule for detecting collisions between two
             // conversions: conversion signatures consist only of the source and target
             // types of the conversions, and not the kind of the conversion (implicit or explicit),
             // the name of the method, and so on.
             //
             // Therefore we must detect the following kinds of member name conflicts:
             //
-            // 1. a method, conversion or field has the same name as a (different) field (* see note below) 
+            // 1. a method, conversion or field has the same name as a (different) field (* see note below)
             // 2. a method has the same method signature as another method or conversion
             // 3. a conversion has the same conversion signature as another conversion.
             //
-            // However, we must *not* detect "a conversion has the same *method* signature 
-            // as another conversion" because conversions are allowed to overload on 
+            // However, we must *not* detect "a conversion has the same *method* signature
+            // as another conversion" because conversions are allowed to overload on
             // return type but methods are not.
             //
             // (*) NOTE: Throughout the rest of this method I will use "field" as a shorthand for
-            // "non-method, non-conversion, non-type member", rather than spelling out 
+            // "non-method, non-conversion, non-type member", rather than spelling out
             // "field, property or event...")
 
             foreach (var pair in membersByName)
@@ -1562,7 +1580,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // * a field directly following a field
                     // * a field directly following a method or conversion
                     //
-                    // Furthermore: we do not wish to detect collisions between nested types in 
+                    // Furthermore: we do not wish to detect collisions between nested types in
                     // this code; that is tested elsewhere. However, we do wish to detect a collision
                     // between a nested type and a field, method or conversion. Therefore we
                     // initialize our "bad transition" detector with a type of the given name,
@@ -1578,8 +1596,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     //
                     // If either the current symbol or the "last symbol" are not methods then
                     // there must be a collision:
-                    // 
-                    // * if the current symbol is not a method and the last symbol is, then 
+                    //
+                    // * if the current symbol is not a method and the last symbol is, then
                     //   there is a field directly following a method of the same name
                     // * if the current symbol is a method and the last symbol is not, then
                     //   there is a method directly or indirectly following a field of the same name,
@@ -1737,7 +1755,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var indexersBySignature = new Dictionary<PropertySymbol, PropertySymbol>(MemberSignatureComparer.DuplicateSourceComparer);
 
-            // Note: Can't assume that all indexers are called WellKnownMemberNames.Indexer because 
+            // Note: Can't assume that all indexers are called WellKnownMemberNames.Indexer because
             // they may be explicit interface implementations.
             foreach (var members in membersByName.Values)
             {
@@ -1995,17 +2013,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private void CheckForUnmatchedOperators(DiagnosticBag diagnostics)
         {
             // SPEC: The true and false unary operators require pairwise declaration.
-            // SPEC: A compile-time error occurs if a class or struct declares one 
+            // SPEC: A compile-time error occurs if a class or struct declares one
             // SPEC: of these operators without also declaring the other.
             //
             // SPEC DEFICIENCY: The line of the specification quoted above should say
             // the same thing as the lines below: that the formal parameters of the
-            // paired true/false operators must match exactly. You can't do 
+            // paired true/false operators must match exactly. You can't do
             // op true(S) and op false(S?) for example.
 
             // SPEC: Certain binary operators require pairwise declaration. For every
             // SPEC: declaration of either operator of a pair, there must be a matching
-            // SPEC: declaration of the other operator of the pair. Two operator 
+            // SPEC: declaration of the other operator of the pair. Two operator
             // SPEC: declarations match when they have the same return type and the same
             // SPEC: type for each parameter. The following operators require pairwise
             // SPEC: declaration: == and !=, > and <, >= and <=.
@@ -2976,8 +2994,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // constants don't count, since they do not exist as fields at runtime
-            // NOTE: even for decimal constants (which require field initializers), 
-            // we do not create .cctor here since a static constructor implicitly created for a decimal 
+            // NOTE: even for decimal constants (which require field initializers),
+            // we do not create .cctor here since a static constructor implicitly created for a decimal
             // should not appear in the list returned by public API like GetMembers().
             if (!hasStaticConstructor && HasNonConstantInitializer(staticInitializers))
             {
@@ -3133,7 +3151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                             // TODO: can we leave this out of the member list?
                             // From the 10/12/11 design notes:
-                            //   In addition, we will change autoproperties to behavior in 
+                            //   In addition, we will change autoproperties to behavior in
                             //   a similar manner and make the autoproperty fields private.
                             if ((object)backingField != null)
                             {
@@ -3293,7 +3311,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 var innerStatement = globalStatement;
 
-                                // drill into any LabeledStatements 
+                                // drill into any LabeledStatements
                                 while (innerStatement.Kind() == SyntaxKind.LabeledStatement)
                                 {
                                     innerStatement = ((LabeledStatementSyntax)innerStatement).Statement;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -338,18 +338,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // @davidmo On a class declaration where one has partial and the other does not, treat the other
             // as if it did.  This is to get around adding code to classes needing partial class on any user class
             // we want to extend as a part of our Source Generation step.
-            var hasCompilerGenAttribute = false;
-            foreach (var decl in declaration.Declarations)
-            {
-                if (decl.HasAnyAttributes)
-                {
-                    hasCompilerGenAttribute = decl.SyntaxReference.GetSyntax().ChildNodes().OfType<AttributeListSyntax>()
-                        .Where((attribList => attribList.ToString().Contains("CompilerGenerated"))).Any();
-                }
-
-                if (hasCompilerGenAttribute)
-                    break;
-            }
+var hasCompilerGenAttribute = declaration.Declarations
+    .Any(decl =>
+    {
+        return decl.HasAnyAttributes &&
+                decl.SyntaxReference.GetSyntax().ChildNodes().OfType<AttributeListSyntax>()
+                .Where((attribList => attribList.ToString().Contains("CompilerGenerated"))).Any();
+    });
 
             for (var i = 0; i < partCount; i++)
             {


### PR DESCRIPTION
`MergeTypeDeclaration`s that have a one or more `[CompilerGenerated]`
attributes defined on any of the compilation unit class definitions
then compile as `partial` implicitly.